### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,9 @@ on:
       - "**.gif"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -22,6 +22,8 @@ concurrency:
 
 jobs:
   syntax-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/YousefHadder/tmux-speedtest/security/code-scanning/1](https://github.com/YousefHadder/tmux-speedtest/security/code-scanning/1)

In general, the fix is to explicitly set `permissions` for the workflow or for the specific job so that the GITHUB_TOKEN only has the minimal scopes required. For this `syntax-check` job, it only needs to read repository contents (to check out the code), so `contents: read` is sufficient.

The best minimal fix without changing existing functionality is to add a `permissions` block at the job level under `syntax-check:` in `.github/workflows/syntax.yml`. This way, only this job gets restricted permissions, and we don’t alter behavior elsewhere. Specifically, between `syntax-check:` (line 24) and `runs-on: ubuntu-latest` (line 25), insert:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
