### PR TITLE
feat: add speedtest cooldown and rate-limit backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ set -g @speedtest_notifications 'on'
 
 # Timeout in seconds for each test (default: 120)
 set -g @speedtest_timeout '120'
+
+# Minimum time between tests (default: 0, disabled)
+# Supports same syntax as @speedtest_interval (e.g., 30s, 5m, 1h30m)
+set -g @speedtest_min_interval '0'
+
+# Temporary backoff duration after provider rate-limit response (default: 10m)
+# Use 0/off/disabled to disable automatic backoff
+set -g @speedtest_rate_limit_backoff '10m'
 ```
 
 ### Auto-Run
@@ -285,6 +293,20 @@ Make sure `#{speedtest_result}` is in your `status-right` or `status-left` confi
 
 ### Test fails
 Check your internet connection. Try running `speedtest`, `fast`, or `speedtest-cli` directly in terminal to see detailed errors.
+
+### Hitting provider rate limits while reloading tmux often
+Use cooldown and backoff settings to reduce test frequency:
+```bash
+# Prevent tests from running too frequently
+set -g @speedtest_min_interval '5m'
+
+# If provider reports rate-limit, wait before retrying
+set -g @speedtest_rate_limit_backoff '15m'
+
+# During heavy config iteration, disable auto-runs temporarily
+set -g @speedtest_run_on_start 'off'
+set -g @speedtest_interval '0'
+```
 
 ### Detail popup opens in a split pane instead of a popup
 The `display-popup` command requires tmux 3.2 or later. On older versions, the plugin automatically falls back to a split pane.

--- a/scripts/clear.sh
+++ b/scripts/clear.sh
@@ -31,7 +31,7 @@ fi
 
 # Reset the result option to the idle icon (or empty string)
 set_tmux_option "@speedtest_result" "$ICON_IDLE"
-set_tmux_option "@speedtest_last_run" "0"
+persist_last_run_timestamp "0"
 
 # Clear stored detail data
 set_tmux_option "@speedtest_result_json" ""

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -525,6 +525,8 @@ ping_to_ms() {
 
 LOCK_FILE="/tmp/tmux-speedtest.lock"
 LOCK_MAX_AGE=300
+LAST_RUN_FILE="/tmp/tmux-speedtest-last-run"
+BACKOFF_UNTIL_FILE="/tmp/tmux-speedtest-backoff-until"
 
 # Get age of a file in seconds (cross-platform)
 file_age_seconds() {
@@ -624,6 +626,124 @@ parse_time_to_seconds() {
 # Get current Unix timestamp
 get_current_timestamp() {
     date +%s
+}
+
+# Read a Unix timestamp from file
+# Returns 0 if file is missing/corrupt
+read_timestamp_file() {
+    local file="$1"
+    local value
+
+    if [[ ! -f "$file" ]]; then
+        echo "0"
+        return
+    fi
+
+    value=$(cat "$file" 2>/dev/null)
+    if [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$value"
+    else
+        echo "0"
+    fi
+}
+
+# Write Unix timestamp to file (best effort)
+write_timestamp_file() {
+    local file="$1"
+    local timestamp="$2"
+
+    if [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+        printf "%s" "$timestamp" > "$file" 2>/dev/null
+    fi
+}
+
+# Get last successful run timestamp from tmux option or persisted file
+get_last_run_timestamp() {
+    local tmux_last_run
+    local file_last_run
+
+    tmux_last_run=$(get_tmux_option "@speedtest_last_run" "0")
+    file_last_run=$(read_timestamp_file "$LAST_RUN_FILE")
+
+    if ! [[ "$tmux_last_run" =~ ^[0-9]+$ ]]; then
+        tmux_last_run="0"
+    fi
+
+    if [[ "$tmux_last_run" -ge "$file_last_run" ]]; then
+        echo "$tmux_last_run"
+    else
+        echo "$file_last_run"
+    fi
+}
+
+# Persist last successful run timestamp in tmux and /tmp for restart survival
+persist_last_run_timestamp() {
+    local timestamp="$1"
+
+    if ! [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+        return
+    fi
+
+    set_tmux_option "@speedtest_last_run" "$timestamp"
+    write_timestamp_file "$LAST_RUN_FILE" "$timestamp"
+}
+
+# Get active backoff-until timestamp from tmux option or persisted file
+get_backoff_until_timestamp() {
+    local tmux_backoff_until
+    local file_backoff_until
+
+    tmux_backoff_until=$(get_tmux_option "@speedtest_backoff_until" "0")
+    file_backoff_until=$(read_timestamp_file "$BACKOFF_UNTIL_FILE")
+
+    if ! [[ "$tmux_backoff_until" =~ ^[0-9]+$ ]]; then
+        tmux_backoff_until="0"
+    fi
+
+    if [[ "$tmux_backoff_until" -ge "$file_backoff_until" ]]; then
+        echo "$tmux_backoff_until"
+    else
+        echo "$file_backoff_until"
+    fi
+}
+
+# Persist backoff-until timestamp in tmux and /tmp for restart survival
+set_backoff_until_timestamp() {
+    local timestamp="$1"
+
+    if ! [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+        return
+    fi
+
+    set_tmux_option "@speedtest_backoff_until" "$timestamp"
+    write_timestamp_file "$BACKOFF_UNTIL_FILE" "$timestamp"
+}
+
+# Clear persisted backoff state
+clear_backoff_until_timestamp() {
+    set_tmux_option "@speedtest_backoff_until" "0"
+    rm -f "$BACKOFF_UNTIL_FILE"
+}
+
+# Return backoff remaining seconds, clearing stale backoff automatically
+get_backoff_remaining_seconds() {
+    local backoff_until
+    local now
+
+    backoff_until=$(get_backoff_until_timestamp)
+    if [[ "$backoff_until" -eq 0 ]]; then
+        echo "0"
+        return
+    fi
+
+    now=$(get_current_timestamp)
+    if [[ "$backoff_until" -le "$now" ]]; then
+        clear_backoff_until_timestamp
+        echo "0"
+        return
+    fi
+
+    echo $((backoff_until - now))
 }
 
 # Check if speedtest result has expired

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -525,8 +525,37 @@ ping_to_ms() {
 
 LOCK_FILE="/tmp/tmux-speedtest.lock"
 LOCK_MAX_AGE=300
-LAST_RUN_FILE="/tmp/tmux-speedtest-last-run"
-BACKOFF_UNTIL_FILE="/tmp/tmux-speedtest-backoff-until"
+CURRENT_UID="${UID:-0}"
+STATE_DIR="${XDG_RUNTIME_DIR:-/tmp}/tmux-speedtest-${CURRENT_UID}"
+
+if [[ -L "$STATE_DIR" ]]; then
+    STATE_DIR=""
+elif [[ -d "$STATE_DIR" ]]; then
+    state_owner_uid=$(stat -f %u "$STATE_DIR" 2>/dev/null)
+    if [[ -z "$state_owner_uid" ]]; then
+        state_owner_uid=$(stat -c %u "$STATE_DIR" 2>/dev/null)
+    fi
+
+    if [[ "$state_owner_uid" != "$CURRENT_UID" || ! -w "$STATE_DIR" ]]; then
+        STATE_DIR=""
+    else
+        chmod 700 "$STATE_DIR" 2>/dev/null
+    fi
+else
+    if mkdir -p "$STATE_DIR" 2>/dev/null; then
+        chmod 700 "$STATE_DIR" 2>/dev/null
+    else
+        STATE_DIR=""
+    fi
+fi
+
+if [[ -n "$STATE_DIR" ]]; then
+    LAST_RUN_FILE="$STATE_DIR/last-run"
+    BACKOFF_UNTIL_FILE="$STATE_DIR/backoff-until"
+else
+    LAST_RUN_FILE=""
+    BACKOFF_UNTIL_FILE=""
+fi
 
 # Get age of a file in seconds (cross-platform)
 file_age_seconds() {
@@ -628,13 +657,27 @@ get_current_timestamp() {
     date +%s
 }
 
+# Return whether a state file is a regular file and not a symlink
+is_safe_state_file() {
+    local file="$1"
+    [[ -n "$file" && -f "$file" && ! -L "$file" ]]
+}
+
+# Remove state file only when it is a regular non-symlink
+remove_state_file() {
+    local file="$1"
+    if is_safe_state_file "$file"; then
+        rm -f "$file"
+    fi
+}
+
 # Read a Unix timestamp from file
 # Returns 0 if file is missing/corrupt
 read_timestamp_file() {
     local file="$1"
     local value
 
-    if [[ ! -f "$file" ]]; then
+    if ! is_safe_state_file "$file"; then
         echo "0"
         return
     fi
@@ -652,9 +695,23 @@ write_timestamp_file() {
     local file="$1"
     local timestamp="$2"
 
-    if [[ "$timestamp" =~ ^[0-9]+$ ]]; then
-        printf "%s" "$timestamp" > "$file" 2>/dev/null
+    if ! [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+        return
     fi
+
+    if [[ -z "$file" ]]; then
+        return
+    fi
+
+    if [[ -e "$file" && ! -f "$file" ]]; then
+        return
+    fi
+
+    if [[ -L "$file" ]]; then
+        return
+    fi
+
+    printf "%s" "$timestamp" > "$file" 2>/dev/null
 }
 
 # Get last successful run timestamp from tmux option or persisted file
@@ -685,7 +742,12 @@ persist_last_run_timestamp() {
     fi
 
     set_tmux_option "@speedtest_last_run" "$timestamp"
-    write_timestamp_file "$LAST_RUN_FILE" "$timestamp"
+
+    if [[ "$timestamp" == "0" ]]; then
+        remove_state_file "$LAST_RUN_FILE"
+    else
+        write_timestamp_file "$LAST_RUN_FILE" "$timestamp"
+    fi
 }
 
 # Get active backoff-until timestamp from tmux option or persisted file
@@ -716,13 +778,17 @@ set_backoff_until_timestamp() {
     fi
 
     set_tmux_option "@speedtest_backoff_until" "$timestamp"
-    write_timestamp_file "$BACKOFF_UNTIL_FILE" "$timestamp"
+    if [[ "$timestamp" == "0" ]]; then
+        remove_state_file "$BACKOFF_UNTIL_FILE"
+    else
+        write_timestamp_file "$BACKOFF_UNTIL_FILE" "$timestamp"
+    fi
 }
 
 # Clear persisted backoff state
 clear_backoff_until_timestamp() {
     set_tmux_option "@speedtest_backoff_until" "0"
-    rm -f "$BACKOFF_UNTIL_FILE"
+    remove_state_file "$BACKOFF_UNTIL_FILE"
 }
 
 # Return backoff remaining seconds, clearing stale backoff automatically
@@ -761,7 +827,7 @@ is_result_expired() {
     fi
 
     local last_run
-    last_run=$(get_tmux_option "@speedtest_last_run" "0")
+    last_run=$(get_last_run_timestamp)
 
     # No test has been run
     if [[ "$last_run" == "0" || -z "$last_run" ]]; then

--- a/scripts/speedtest.sh
+++ b/scripts/speedtest.sh
@@ -23,41 +23,15 @@ is_rate_limit_error() {
        "$normalized" == *"too many test"* || \
        "$normalized" == *"try again later"* || \
        "$normalized" == *"quota"* || \
-       "$normalized" == *"429"* ]]
+       "$normalized" == *"http 429"* || \
+       "$normalized" == *"error 429"* || \
+       "$normalized" == *"429 too many"* || \
+       "$normalized" == *"status code: 429"* ]]
 }
 
 # Run the actual speedtest in background
 run_speedtest_background() {
-    # Atomically acquire lock — exit if another process won the race
-    if ! acquire_lock; then
-        tmux display-message "speedtest: Already running..."
-        exit 0
-    fi
-    local stdout_file=""
-    local stderr_file=""
-    cleanup_run() {
-        [[ -n "$stdout_file" ]] && rm -f "$stdout_file"
-        [[ -n "$stderr_file" ]] && rm -f "$stderr_file"
-        release_lock
-    }
-    trap cleanup_run EXIT
-
     NOTIFICATIONS_ENABLED=$(get_tmux_option "@speedtest_notifications" "on")
-
-    # Configuration
-    FORMAT=$(get_tmux_option "@speedtest_format" "↓ #{download} ↑ #{upload} #{ping}")
-    ICON_RUNNING=$(get_tmux_option "@speedtest_icon_running" "⏳")
-    ICON_IDLE=$(get_tmux_option "@speedtest_icon_idle" "—")
-    SERVER=$(get_tmux_option "@speedtest_server" "")
-
-    # Store current result (to restore on failure)
-    # If currently hidden (empty), use idle icon as fallback
-    CURRENT_VAL=$(get_tmux_option "@speedtest_result" "")
-    if [[ -z "$CURRENT_VAL" ]]; then
-        PREVIOUS_RESULT="$ICON_IDLE"
-    else
-        PREVIOUS_RESULT="$CURRENT_VAL"
-    fi
 
     # Respect temporary backoff after provider throttling
     BACKOFF_REMAINING=$(get_backoff_remaining_seconds)
@@ -84,6 +58,35 @@ run_speedtest_background() {
                 exit 0
             fi
         fi
+    fi
+
+    # Atomically acquire lock — exit if another process won the race
+    if ! acquire_lock; then
+        tmux display-message "speedtest: Already running..."
+        exit 0
+    fi
+    local stdout_file=""
+    local stderr_file=""
+    cleanup_run() {
+        [[ -n "$stdout_file" ]] && rm -f "$stdout_file"
+        [[ -n "$stderr_file" ]] && rm -f "$stderr_file"
+        release_lock
+    }
+    trap cleanup_run EXIT
+
+    # Configuration
+    FORMAT=$(get_tmux_option "@speedtest_format" "↓ #{download} ↑ #{upload} #{ping}")
+    ICON_RUNNING=$(get_tmux_option "@speedtest_icon_running" "⏳")
+    ICON_IDLE=$(get_tmux_option "@speedtest_icon_idle" "—")
+    SERVER=$(get_tmux_option "@speedtest_server" "")
+
+    # Store current result (to restore on failure)
+    # If currently hidden (empty), use idle icon as fallback
+    CURRENT_VAL=$(get_tmux_option "@speedtest_result" "")
+    if [[ -z "$CURRENT_VAL" ]]; then
+        PREVIOUS_RESULT="$ICON_IDLE"
+    else
+        PREVIOUS_RESULT="$CURRENT_VAL"
     fi
 
     if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then

--- a/scripts/speedtest.sh
+++ b/scripts/speedtest.sh
@@ -12,6 +12,20 @@ if [[ -f "$LOCK_FILE" ]]; then
     release_lock
 fi
 
+# Check if provider response indicates throttling/rate limiting
+is_rate_limit_error() {
+    local raw="$1"
+    local normalized
+    normalized=$(echo "$raw" | tr '[:upper:]' '[:lower:]')
+
+    [[ "$normalized" == *"rate limit"* || \
+       "$normalized" == *"too many request"* || \
+       "$normalized" == *"too many test"* || \
+       "$normalized" == *"try again later"* || \
+       "$normalized" == *"quota"* || \
+       "$normalized" == *"429"* ]]
+}
+
 # Run the actual speedtest in background
 run_speedtest_background() {
     # Atomically acquire lock — exit if another process won the race
@@ -19,11 +33,16 @@ run_speedtest_background() {
         tmux display-message "speedtest: Already running..."
         exit 0
     fi
-    trap 'release_lock' EXIT
+    local stdout_file=""
+    local stderr_file=""
+    cleanup_run() {
+        [[ -n "$stdout_file" ]] && rm -f "$stdout_file"
+        [[ -n "$stderr_file" ]] && rm -f "$stderr_file"
+        release_lock
+    }
+    trap cleanup_run EXIT
 
-    if [[ "$(get_tmux_option "@speedtest_notifications" "on")" != "off" ]]; then
-        tmux display-message "speedtest: Starting..."
-    fi
+    NOTIFICATIONS_ENABLED=$(get_tmux_option "@speedtest_notifications" "on")
 
     # Configuration
     FORMAT=$(get_tmux_option "@speedtest_format" "↓ #{download} ↑ #{upload} #{ping}")
@@ -38,6 +57,37 @@ run_speedtest_background() {
         PREVIOUS_RESULT="$ICON_IDLE"
     else
         PREVIOUS_RESULT="$CURRENT_VAL"
+    fi
+
+    # Respect temporary backoff after provider throttling
+    BACKOFF_REMAINING=$(get_backoff_remaining_seconds)
+    if [[ "$BACKOFF_REMAINING" -gt 0 ]]; then
+        if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then
+            tmux display-message "speedtest: Backoff active (${BACKOFF_REMAINING}s remaining)"
+        fi
+        exit 0
+    fi
+
+    # Optional minimum time between tests (survives tmux restart)
+    MIN_INTERVAL_OPTION=$(get_tmux_option "@speedtest_min_interval" "0")
+    MIN_INTERVAL_SECS=$(parse_time_to_seconds "$MIN_INTERVAL_OPTION")
+    if [[ "$MIN_INTERVAL_SECS" -gt 0 ]]; then
+        LAST_RUN_TS=$(get_last_run_timestamp)
+        if [[ "$LAST_RUN_TS" -gt 0 ]]; then
+            NOW_TS=$(get_current_timestamp)
+            AGE_SECS=$((NOW_TS - LAST_RUN_TS))
+            if [[ "$AGE_SECS" -lt "$MIN_INTERVAL_SECS" ]]; then
+                REMAINING_SECS=$((MIN_INTERVAL_SECS - AGE_SECS))
+                if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then
+                    tmux display-message "speedtest: Cooldown active (${REMAINING_SECS}s remaining)"
+                fi
+                exit 0
+            fi
+        fi
+    fi
+
+    if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then
+        tmux display-message "speedtest: Starting..."
     fi
 
     # Show running indicator
@@ -63,7 +113,7 @@ run_speedtest_background() {
     local requested_provider
     requested_provider=$(get_tmux_option "@speedtest_provider" "auto")
     if [[ "$requested_provider" != "auto" && "$CLI_TYPE" != "$requested_provider" ]]; then
-        if [[ "$(get_tmux_option "@speedtest_notifications" "on")" != "off" ]]; then
+        if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then
             tmux display-message "speedtest: '$requested_provider' not found, using $CLI_TYPE instead"
         fi
     fi
@@ -97,37 +147,47 @@ run_speedtest_background() {
 
     # Execute with timeout — try coreutils timeout first, fall back to bg+sleep+kill
     local EXIT_CODE
+    local ERROR_OUTPUT
+    stdout_file=$(mktemp)
+    stderr_file=$(mktemp)
+
     if command -v timeout &>/dev/null; then
-        OUTPUT=$(timeout "$TIMEOUT_SECS" "${cmd[@]}" 2>/dev/null)
+        timeout "$TIMEOUT_SECS" "${cmd[@]}" > "$stdout_file" 2> "$stderr_file"
         EXIT_CODE=$?
     else
-        local tmpfile
-        tmpfile=$(mktemp)
-        trap 'rm -f "$tmpfile"; release_lock' EXIT
-        "${cmd[@]}" > "$tmpfile" 2>/dev/null &
+        "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" &
         local child=$!
         ( sleep "$TIMEOUT_SECS" && kill "$child" 2>/dev/null ) &
         local watcher=$!
         wait "$child" 2>/dev/null
-        local child_exit=$?
-        if [[ $child_exit -eq 0 ]]; then
-            OUTPUT=$(cat "$tmpfile")
-        else
-            OUTPUT=""
-        fi
+        EXIT_CODE=$?
         kill "$watcher" 2>/dev/null
         wait "$watcher" 2>/dev/null
-        rm -f "$tmpfile"
-        EXIT_CODE=$child_exit
     fi
 
+    OUTPUT=$(cat "$stdout_file")
+    ERROR_OUTPUT=$(cat "$stderr_file")
+
     if [[ $EXIT_CODE -ne 0 || -z "$OUTPUT" ]]; then
-        tmux display-message "speedtest: Test failed"
+        if is_rate_limit_error "$ERROR_OUTPUT$OUTPUT"; then
+            BACKOFF_OPTION=$(get_tmux_option "@speedtest_rate_limit_backoff" "10m")
+            BACKOFF_SECS=$(parse_time_to_seconds "$BACKOFF_OPTION")
+            if [[ "$BACKOFF_SECS" -gt 0 ]]; then
+                set_backoff_until_timestamp "$(( $(get_current_timestamp) + BACKOFF_SECS ))"
+                tmux display-message "speedtest: Rate-limited; backing off for ${BACKOFF_SECS}s"
+            else
+                tmux display-message "speedtest: Rate-limited by provider"
+            fi
+        else
+            tmux display-message "speedtest: Test failed"
+        fi
         sleep 2
         set_tmux_option "@speedtest_result" "$PREVIOUS_RESULT"
         tmux refresh-client -S
         exit 1
     fi
+
+    clear_backoff_until_timestamp
 
     # Parse results based on CLI type
     local download upload ping_val
@@ -222,7 +282,7 @@ run_speedtest_background() {
 
     # Update status bar
     set_tmux_option "@speedtest_result" "$RESULT"
-    set_tmux_option "@speedtest_last_run" "$(get_current_timestamp)"
+    persist_last_run_timestamp "$(get_current_timestamp)"
     tmux refresh-client -S
 
     # Store full results for detail popup
@@ -231,7 +291,7 @@ run_speedtest_background() {
     set_tmux_option "@speedtest_result_provider" "$CLI_TYPE"
 
     # Show notification if not disabled
-    if [[ "$(get_tmux_option "@speedtest_notifications" "on")" != "off" ]]; then
+    if [[ "$NOTIFICATIONS_ENABLED" != "off" ]]; then
         tmux display-message "speedtest: Done - $RESULT"
     fi
 }

--- a/scripts/speedtest_status.sh
+++ b/scripts/speedtest_status.sh
@@ -12,7 +12,7 @@ RESULT=$(get_tmux_option "@speedtest_result" "")
 # Check if result has expired
 if [[ -n "$RESULT" && "$RESULT" != "$ICON_IDLE" ]] && is_result_expired; then
     set_tmux_option "@speedtest_result" "$ICON_IDLE"
-    set_tmux_option "@speedtest_last_run" "0"
+    persist_last_run_timestamp "0"
     RESULT="$ICON_IDLE"
 fi
 

--- a/speedtest.tmux
+++ b/speedtest.tmux
@@ -16,8 +16,10 @@ tmux bind-key "$DETAIL_KEY" run-shell -b "$CURRENT_DIR/scripts/popup_detail.sh"
 
 # Set up status bar interpolation
 # This allows users to use #{speedtest_result} in their status bar
-# Default to empty string so it doesn't show initially if auto-hide is desired
-tmux set-option -gq @speedtest_result "$(get_tmux_option "@speedtest_icon_idle" "—")"
+# Only initialize if unset to avoid resetting state on every source-file
+if ! tmux show-option -g @speedtest_result >/dev/null 2>&1; then
+    tmux set-option -gq @speedtest_result "$(get_tmux_option "@speedtest_icon_idle" "—")"
+fi
 
 # Set up status interpolation script path
 STATUS_SCRIPT="$CURRENT_DIR/scripts/speedtest_status.sh"


### PR DESCRIPTION
## Summary
- add minimum interval gating via `@speedtest_min_interval`
- add automatic rate-limit backoff via `@speedtest_rate_limit_backoff`
- persist last-run and backoff timestamps under `/tmp` to survive tmux restarts
- avoid resetting `@speedtest_result` on every `source-file`
- document new options and rate-limit troubleshooting in README

## Validation
- `bash -n speedtest.tmux`
- `for script in scripts/*.sh; do bash -n "$script"; done`
- ShellCheck not run locally (not installed)
